### PR TITLE
Add notice under link shorteners to prevent link rot.

### DIFF
--- a/README.md
+++ b/README.md
@@ -1444,8 +1444,7 @@ See https://staticsitegenerators.net and https://www.staticgen.com
 
 ## URL Shorteners
 
-URL Shorteners are a ticking time bomb. If they go away, get hacked, or sell out, millions of links will be lost. 
-If you decide to host one, please add it to [Archive Team](https://www.archiveteam.org/)'s [URLTeam](https://www.archiveteam.org/index.php?title=URLTeam) list of Alive URLs.
+Before hosting one, please see [shortcomings](https://en.wikipedia.org/wiki/URL_shortening#Shortcomings) of URL shorteners.
 
 **[`^        back to top        ^`](#)**
 

--- a/README.md
+++ b/README.md
@@ -1444,6 +1444,9 @@ See https://staticsitegenerators.net and https://www.staticgen.com
 
 ## URL Shorteners
 
+URL Shorteners are a ticking time bomb. If they go away, get hacked, or sell out, millions of links will be lost. 
+If you decide to host one, please add it to [Archive Team](https://www.archiveteam.org/)'s [URLTeam](https://www.archiveteam.org/index.php?title=URLTeam) list of Alive URLs.
+
 **[`^        back to top        ^`](#)**
 
 - [devShort](https://github.com/flokX/devShort) - A simple and privacy-friendly URL shortener for web developers, admins and all professionals. ([Demo](https://devshort.flokx.dev)) `MIT` `PHP`


### PR DESCRIPTION
TinyURL, bit.ly, and other similar services allow long URLs to be converted to smaller ones on their specific service; the small URL is visited by a consumer and their web browser is redirected to the long URL.

Such services are a ticking timebomb. If they go away, get hacked, or sell out, millions of links will be lost (see [Wikipedia: Link Rot](https://en.wikipedia.org/wiki/Link_rot)). [Archive.org/301Works](https://archive.org/details/301works) is acting as an escrow for URL shortener databases, but they rely on URL shorteners to actually give them their databases. Even 301Works founding member bit.ly does not actually share their databases and most other big shorteners don't share theirs either. 

- [x] You have searched the repository for any relevant [issues](https://github.com/awesome-selfhosted/awesome-selfhosted/issues) or [PRs](https://github.com/awesome-selfhosted/awesome-selfhosted/pulls), including closed ones.
- [x] Any software project you are adding to the list is actively maintained.