### PR TITLE
Zimbra is no longer awesome

### DIFF
--- a/README.md
+++ b/README.md
@@ -849,7 +849,6 @@ _Games, game servers and control panels._
 - [SOGo](https://sogo.nu/) - SOGo offers multiple ways to access the calendaring and messaging data. CalDAV, CardDAV, GroupDAV, as well as ActiveSync, including native Outlook compatibility and Web interface. ([Demo](http://demo.sogo.nu/SOGo/), [Source Code](https://github.com/inverse-inc/sogo)) `LGPL-2.1` `Objective-C`
 - [SuiteCRM](http://www.suitecrm.com/) - The award-winning, enterprise-class open source CRM. ([Source Code](https://github.com/salesagility/SuiteCRM)) `AGPL-3.0` `PHP`
 - [Tine 2.0](https://www.tine20.org) - Contacts, Calendar, Tasks, WebDAV, ActiveSync, VOIP, Mail-Client, CRM, Sales, Projects, Timetracker. ([Demo](https://demo.tine20.net), [Source Code](https://packages.tine20.com/maintenance/source/)) `AGPL-3.0/Other` `PHP`
-- [Zimbra Collaboration](https://www.zimbra.com/) - Email, calendar, collaboration server with Web interface and lots of integrations. ([Source Code](https://github.com/zimbra)) `GPL-2.0/CPAL-1.0` `Java`
 
 ## Human Resources Management (HRM)
 


### PR DESCRIPTION
Zimbra is now proprietary closed software
https://forums.zimbra.org/viewtopic.php?t=68073

> Changes To Zimbra’s Open Source Policy
John E. explained that Zimbra 9 introduces a change to Synacor’s open source policy for Zimbra. Starting with Zimbra 9, a binary version of Zimbra 9 will no longer be released to the community and will instead only be made available to Zimbra Network Edition customers. There are currently no plans to release the source code for Zimbra 9 to the community. Zimbra 8.8.15 will remain open source for the community and continue to be supported for the remainder of its lifecycle through December, 31, 2024 (https://www.zimbra.com/support/support-offerings/product-lifecycle/). Version 8.8.15 will also continue to receive patches during this time frame. John E. described this new model for Zimbra 9 as “open core” where the open source products on which Zimbra is built will continue to be freely available, but the Zimbra 9 product itself will not be open source. Marc G. asked if Synacor’s plans involved introducing new features to Zimbra 8.8.15, or if the focus for introducing new features will shift exclusively to version 9. John E. said that he did not have the answer to this question. John also shared that starting with Zimbra 9, a source code license will be made available to customers who are licensing Zimbra Network Edition.