### PR TITLE
Remove IG Monitoring

### DIFF
--- a/README.md
+++ b/README.md
@@ -139,7 +139,6 @@ _Business Intelligence_
 
 _Social Media_
 
-- [IG Monitoring](https://igmonitoring.com) - `⚠` Instagram Analytics and Stats. ([Demo](https://demo.igmonitoring.com), [Source Code](https://github.com/jakim/ig-monitoring)) `MIT` `PHP`
 - [Socioboard](https://socioboard.org/) - `⚠` Social media management, analytics, and reporting platform supporting nine social media networks out-of-the-box. ([Source Code](https://github.com/socioboard/Socioboard-4.0)) `GPL-3.0` `C#/JavaScript`
 
 ## Archiving and Digital Preservation (DP)


### PR DESCRIPTION
IG Monitoring will no longer be developed or actively supported and should be removed from the list. 
see https://github.com/jakim/ig-monitoring/issues/138