### PR TITLE
Updating transfer.sh link

### DIFF
--- a/README.md
+++ b/README.md
@@ -789,7 +789,7 @@ _See https://github.com/n1trux/awesome-sysadmin#distributed-filesystems_
 #### Command-line file upload
 
 - [Beauties](https://github.com/dsx/beauties) - Minimalist file sharing written in Go, to be used primarily from Unix shell (e.g. with curl). Can be built as a Debian package for easy install. `MIT` `Go`
-- [transfer.sh](https://transfer.sh) - Easy file sharing from the command line. ([Source Code](https://github.com/dutchcoders/transfer.sh)) `MIT` `Go`
+- [transfer.sh](https://github.com/dutchcoders/transfer.sh/) - Easy file sharing from the command line. ([Source Code](https://github.com/dutchcoders/transfer.sh)) `MIT` `Go`
 
 #### Web based file managers
 


### PR DESCRIPTION
Removing the checklist as I am only issuing an update:

Replaced the transfer.sh link, as the original one is reported as "The service at https://transfersh.com is of unknown origin and reported as cloud malware.", as stated by the developer in the repository, and should hence not be published here (or anywhere else).