### PR TITLE
Demo links should only be used for interactive demos, i.e. not video demonstrations

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -8,6 +8,7 @@ To ensure your PR is dealt with swiftly please check the following:
   Keep the short description under 250 characters and use [sentence case](https://en.wikipedia.org/wiki/Letter_case#Sentence_case)
   for it, even if the project's webpage or readme uses another capitalisation
   such as title case, all caps, small caps or all lowercase.
+  `Demo` links should only be used for interactive demos, i.e. not video demonstrations.
   ``- [Name](http://homepage/) - Short description, under 250 characters, sentence case. ([Demo](http://url.to/demo), [Source Code](http://url.of/source/code), [Clients](https://url.to/list/of/related/clients-or-apps)) `License` `Language` ``
 - [ ] Additions that depend on proprietary services outside the user's control must be marked `⚠`.
   ``- [Name](http://homepage/) `⚠` - Short description, under 250 characters, sentence case. ([Demo](http://url.to/demo), [Source Code](http://url.of/source/code), [Clients](https://url.to/list/of/related/clients-or-apps)) `License` `Language` ``
@@ -15,12 +16,8 @@ To ensure your PR is dealt with swiftly please check the following:
   must be added to `non-free.md` and marked `⊘ Proprietary`:
   ``- [Name](http://homepage/) `⊘ Proprietary` - Short description, under 250 characters, sentence case. ([Demo](http://url.to/demo), [Source Code](http://url.of/source/code), [Clients](https://url.to/list/of/related/clients-or-apps)) `Language` ``
 - [ ] Additions are inserted preserving alphabetical order.
-- [ ] Additions are not already listed at any of
-  - [awesome-sysadmin](https://github.com/n1trux/awesome-sysadmin) (IT infrastructure management),
-  - [awesome-analytics](https://github.com/onurakpolat/awesome-analytics) (analytics),
-  - [staticgen.com](https://www.staticgen.com/)
-  - [staticsitegenerators.net](https://staticsitegenerators.net/) (static site generators).
-- [ ] The `Language` tag is the main server-side requirement for the software - don't include frameworks or specific dialects.
+- [ ] Additions are not already listed at any of [awesome-sysadmin](https://github.com/n1trux/awesome-sysadmin), [awesome-analytics](https://github.com/onurakpolat/awesome-analytics), [staticgen.com](https://www.staticgen.com/), [staticsitegenerators.net](https://staticsitegenerators.net/).
+- [ ] The `Language` tag is the main **server-side** requirement for the software. Don't include frameworks or specific dialects.
 - [ ] Any license you add is in our [list of licenses](https://github.com/awesome-selfhosted/awesome-selfhosted/blob/master/README.md#list-of-licenses).
 - [ ] You have searched the repository for any relevant [issues](https://github.com/awesome-selfhosted/awesome-selfhosted/issues) or [PRs](https://github.com/awesome-selfhosted/awesome-selfhosted/pulls), including closed ones.
 - [ ] Any category you are creating has the minimum requirement of 3 items.

--- a/README.md
+++ b/README.md
@@ -150,7 +150,7 @@ _See also [Internet of Things (IoT)](#internet-of-things-iot)_
 - [Huginn](https://github.com/huginn/huginn) - Allows you to build agents that monitor and act on your behalf. `MIT` `Ruby`
 - [Kibitzr](https://kibitzr.github.io) - Lightweight personal web assistant with powerful integrations. ([Source Code](https://github.com/kibitzr/kibitzr)) `MIT` `Python`
 - [LazyLibrarian](https://gitlab.com/LazyLibrarian/LazyLibrarian) `⚠` - LazyLibrarian is a program to follow authors and grab metadata for all your digital reading needs. It uses a combination of Goodreads Librarything and optionally GoogleBooks as sources for author info and book info. `GPL-3.0` `Python`
-- [Leon](https://getleon.ai) - Open-source personal assistant who can live on your server. ([Demo](https://www.youtube.com/watch?v=p7GRGiicO1c), [Source Code](https://github.com/leon-ai/leon)) `MIT` `Node.js`
+- [Leon](https://getleon.ai) - Open-source personal assistant who can live on your server. ([Source Code](https://github.com/leon-ai/leon)) `MIT` `Node.js`
 - [Lidarr](https://lidarr.audio/) - Lidarr is a music collection manager for Usenet and BitTorrent users. ([Source Code](https://github.com/Lidarr/Lidarr)) `GPL-3.0` `C#`
 - [Medusa](https://github.com/pymedusa/SickRage) - Automatic Video Library Manager for TV Shows. It watches for new episodes of your favorite shows, and when they are posted it does its magic. `GPL-3.0` `Python`
 - [MeTube](https://github.com/alexta69/metube) - Web GUI for youtube-dl, with playlist support. Allows downloading videos from dozens of websites. `AGPL-3.0` `Python/Nodejs/Docker`


### PR DESCRIPTION
- formatting fixes/emphasis
- fixes #2459
- remove demo link for Leon 