### PR TITLE
Remove Blynk, since they retired their self-hosted server completely

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,6 +13,7 @@ See [Contributing](.github/CONTRIBUTING.md).
 
 ## Table of contents
 
+
 Click on the menu icon next to [README.md](#readme) for a list of sections
 
 --------------------
@@ -1098,7 +1099,6 @@ _See also: [List of streaming media systems - Wikipedia](https://en.wikipedia.or
 - [Anchr](https://anchr.io) - Anchr is a toolbox for tiny tasks on the internet, including bookmark collections, URL shortening and (encrypted) image uploads. ([Source Code](https://github.com/muety/anchr)) `GPL-3.0` `Nodejs`
 - [Anuko](https://www.anuko.com/time_tracker/index.htm) - Anuko provides simple time and project tracking on a selfhosted basis. ([Demo](https://timetracker.anuko.com/), [Source Code](https://github.com/anuko/timetracker)) `Other` `PHP`
 - [asciiflow](https://asciiflow.com/) - Flow Diagram Drawing Tool. ([Source Code](https://github.com/lewish/asciiflow)) `MIT` `Nodejs`
-- [blynk](https://blynk.io/) - Platform with iOS and Android apps to control Arduino, ESP8266, Raspberry Pi and similar microcontroller boards over the Internet. ([Source Code](https://github.com/blynkkk/blynk-server)) `AGPL-3.0` `Java`
 - [Cachet](https://cachethq.io/) - An open source status page system for everyone. ([Demo](https://demo.cachethq.io/), [Source Code](https://github.com/CachetHQ/Cachet)) `BSD-3-Clause` `PHP`
 - [CapRover](https://caprover.com/) - Build your own PaaS in a few minutes. ([Demo](https://captain.server.demo.caprover.com/#/login), [Source Code](https://github.com/caprover/caprover)) `Apache-2.0` `Docker/Nodejs`
 - [changedetection.io](https://github.com/dgtlmoon/changedetection.io) - Self-hosted tool for staying up-to-date with web-site content changes. `Apache-2.0` `Python/Docker`


### PR DESCRIPTION
Blynk has now - sadly - completely removed their self-hosted server from their GitHub, when switching to "Blynk 2.0". Now, Blynk is only accessible as a SaaS. There is no more mention of it on their website.

From what I understood, they eventually plan to release a self-hosted (local) version of the 2.0 server, but not in a near future. Also, it will be a paid feature (cf. https://www.reddit.com/r/arduino/comments/oqrbq6/blynk_blynk_local_server_is_no_longer_available/h6h8uy2/ ).

There exist some forks of the original blynk-server repository, but I'm not sure an unofficial fork is compliant with awesome-selfhosted rules to list a project. That's why I removed the entry completely in my PR. Do not hesitate to comment if it needs to be handled differently.

Thank you for taking the time to work on a PR for Awesome-Selfhosted!
