### PR TITLE
Remove Kloudless from non-free as the business no longer offers the software

### DIFF
--- a/non-free.md
+++ b/non-free.md
@@ -107,7 +107,6 @@
 - [Crucible](https://www.atlassian.com/software/crucible/overview) `⊘ Proprietary` - A peer code review application `Java`
 - [Documize](https://documize.com) `⊘ Proprietary` - Modern docs & wiki software built for software team collaboration. `Go`
 - [JIRA](https://www.atlassian.com/software/jira) `⊘ Proprietary` - A professional and extensible issue tracker `Java`
-- [Kloudless](https://kloudless.com) `⊘ Proprietary` - Platform for native, embedded, SaaS integrations using Unified APIs. `Python`
 - [RhodeCode](https://rhodecode.com) `⊘ Proprietary` - On-premise Source Code Management for Mercurial, Git & Subversion. `Python`
 - [BitBucket Server](https://www.atlassian.com/software/bitbucket/server) `⊘ Proprietary` - An enterprise-level Git solution similar to GitLab `Java`
   


### PR DESCRIPTION
I authored the original PR introducing Kloudless at https://github.com/awesome-selfhosted/awesome-selfhosted/commit/05712f870f6580933bd2faaf3cf39a1001a76d29.