### PR TITLE
remove ytdl-webserver (unmaintained since 2019)

### DIFF
--- a/README.md
+++ b/README.md
@@ -1346,7 +1346,6 @@ Software that does not fit in another section.
 - [Wallabag](https://www.wallabag.org) - Wallabag, formerly Poche, is a web application allowing you to save articles to read them later with improved readability. ([Source Code](https://github.com/wallabag/wallabag)) `MIT` `PHP`
 - [WeeWX](https://weewx.com/) - Open source software for your weather station. ([Demo](https://weewx.com/showcase.html), [Source Code](https://github.com/weewx/weewx)) `GPL-3.0` `Python`
 - [WeTTY](https://butlerx.github.io/wetty/#/) - Terminal in browser over http/https. ([Source Code](https://github.com/butlerx/wetty)) `MIT` `Docker/Nodejs`
-- [ytdl-webserver](https://github.com/Algram/ytdl-webserver) - Docker-ready webserver for downloading youtube videos. `MIT` `Nodejs`
 
 
 ### Money, Budgeting & Management


### PR DESCRIPTION
- WARNING:awesome_lint.py: ytdl-webserver: last updated -1229 days, 1:25:17.139521 ago, older than 365 days
- ref. https://github.com/awesome-selfhosted/awesome-selfhosted/issues/3558

