### PR TITLE
Pull Request template: additions should not already be listed at dbdb.io

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -16,7 +16,7 @@ To ensure your PR is dealt with swiftly please check the following:
   ``- [Name](http://homepage/) `⚠` - Short description, under 250 characters, sentence case. ([Demo](http://url.to/demo), [Source Code](http://url.of/source/code), [Clients](https://url.to/list/of/related/clients-or-apps)) `License` `Language` ``
 - [ ] Additions that are not [Free software](https://en.wikipedia.org/wiki/Free_software) must be added to `non-free.md` and have the license set to `⊘ Proprietary`
 - [ ] Additions are inserted preserving alphabetical order.
-- [ ] Additions are not already listed at any of [awesome-sysadmin](https://github.com/n1trux/awesome-sysadmin), [staticgen.com](https://www.staticgen.com/), [staticsitegenerators.net](https://staticsitegenerators.net/).
+- [ ] Additions are not already listed at any of [awesome-sysadmin](https://github.com/n1trux/awesome-sysadmin), [staticgen.com](https://www.staticgen.com/), [staticsitegenerators.net](https://staticsitegenerators.net/), [dbdb.io](https://dbdb.io/browse).
 - [ ] The `Language` tag is the main **server-side** requirement for the software. Don't include frameworks or specific dialects.
 - [ ] Any license you add is in our [list of licenses](https://github.com/awesome-selfhosted/awesome-selfhosted/blob/master/README.md#list-of-licenses).
 - [ ] You have searched the repository for any relevant [issues](https://github.com/awesome-selfhosted/awesome-selfhosted/issues) or [PRs](https://github.com/awesome-selfhosted/awesome-selfhosted/pulls), including closed ones.


### PR DESCRIPTION
https://github.com/awesome-foss/awesome-sysadmin 's "Databases" section has been delegated to https://dbdb.io/browse (https://github.com/awesome-foss/awesome-sysadmin/pull/437), we also want to ensure that there is no duplicate entries across awesome-selfhosted and dbdb.io, as this site does a better job at listing database engines.
