### PR TITLE
Remove Weaviate (already listed at dbdb.io)

### DIFF
--- a/README.md
+++ b/README.md
@@ -1152,7 +1152,6 @@ _Related: [Note-taking & Editors](#note-taking--editors), [Wikis](#wikis), [Data
 - [Mindmaps](https://github.com/drichard/mindmaps) - Open source, offline capable, mind mapping application. ([Demo](https://www.mindmaps.app)) `AGPL-3.0` `HTML5`
 - [My Mind](https://github.com/ondras/my-mind) - Web application for creating and managing mind maps. ([Demo](https://my-mind.github.io/?url=examples%2Ffeatures.mymind)) `MIT` `Javascript`
 - [TeamMapper](https://github.com/b310-digital/teammapper) - Host and create your own mindmaps. Share your mindmap sessions with your team and collaborate live on mindmaps. ([Demo](https://map.kits.blog)) `MIT` `Docker/Nodejs`
-- [Weaviate](https://weaviate.io/) - A cloud-native, realtime vector search engine integrating scalable machine learning models (GraphQL and RESTful APIs). ([Demo](https://github.com/semi-technologies/semantic-search-through-wikipedia-with-weaviate/), [Source Code](https://github.com/semi-technologies/weaviate), [Clients](https://weaviate.io/developers/weaviate/current/client-libraries/index.html)) `BSD-3-Clause` `Go`
 
 
 ### Learning and Courses


### PR DESCRIPTION
- Since https://github.com/awesome-selfhosted/awesome-selfhosted/pull/3811 duplicates between awesome-selfhosted and https://dbdb.io/browse are no longer allowed.
- Weaviate is already listed at https://dbdb.io/db/weaviate
- ref. https://github.com/awesome-selfhosted/awesome-selfhosted/pull/3802
