### PR TITLE
Remove Dispatch (unmaintained since 2022, Website down) from Communication - IRC

### DIFF
--- a/README.md
+++ b/README.md
@@ -480,7 +480,6 @@ Simple deployment of [E-mail](https://en.wikipedia.org/wiki/Email) servers, e.g.
 [IRC](https://en.wikipedia.org/wiki/Internet_Relay_Chat) communication software.
 
 - [Convos](https://convos.chat/) - Always online web IRC client. ([Demo](https://convos.chat/#instant-demo), [Source Code](https://github.com/nordaaker/convos)) `Artistic-2.0` `Perl`
-- [Dispatch](https://github.com/khlieng/dispatch) - Self-hosted web IRC client written in Go. `MIT` `Go`
 - [Ergo](https://ergo.chat/) - Modern IRCv3 server written in Go, combining the features of an ircd, a services framework, and a bouncer. ([Source Code](https://github.com/ergochat/ergo)) `MIT` `Go`
 - [Glowing Bear](https://github.com/glowing-bear/glowing-bear) - A web frontend for WeeChat. ([Demo](https://www.glowing-bear.org)) `GPL-3.0` `Nodejs`
 - [InspIRCd](https://www.inspircd.org/) - Modular IRC server written in C++ for Linux, BSD, Windows, and macOS. ([Source Code](https://github.com/inspircd/inspircd)) `GPL-2.0` `C++`


### PR DESCRIPTION
Opened an Issue in the repository of the project asking if the project is still being maintained.
https://github.com/khlieng/dispatch/issues/114

> Based on my observations, the project raises concerns regarding its maintenance. Firstly, the website associated with the project is currently inaccessible or down. Additionally, there haven't been any updates made to the project's dependencies since March 9, 2021. Furthermore, I've noticed that there are open issues without any identifiable owner or maintainer assigned to them.

ref: #3558 
`WARNING:awesome_lint.py: Dispatch: last updated -490 days, 23:21:48.366298 ago, older than 365 days`