### PR TITLE
Remove Cagette from Community-Supported Agriculture

### DIFF
--- a/README.md
+++ b/README.md
@@ -639,7 +639,6 @@ Management and administration tools for community supported agriculture and food
 _Related: [E-commerce](#e-commerce)_
 
 - [ACP Admin](https://acp-admin.ch/) - CSA administration. Manage members, subscriptions, deliveries, drop-off locations, member participation, invoices and emails. ([Source Code](https://github.com/acp-admin/acp-admin/)) `MIT` `Ruby`
-- [Cagette](https://cagette.net/) - Open source web app to help people build a better and sustainable food system. Some people call it a 'foodhub' - a mix between a groupware and a marketplace, helping consumers to order food from local farmers and producers. ([Source Code](https://github.com/CagetteNet/cagette)) `GPL-2.0` `Haxe`
 - [FoodCoopShop](https://www.foodcoopshop.com/) - User-friendly open source software for food-coops. ([Source Code](https://github.com/foodcoopshop/foodcoopshop)) `AGPL-3.0` `PHP`
 - [Foodsoft](https://foodcoops.net/) - Web-based software to manage a non-profit food coop (product catalog, ordering, accounting, job scheduling). ([Source Code](https://github.com/foodcoops/foodsoft)) `AGPL-3.0` `Ruby`
 - [juntagrico](https://juntagrico.org/) - Management platform for community gardens and vegetable cooperatives. ([Source Code](https://github.com/juntagrico/juntagrico)) `LGPL-3.0` `Python`


### PR DESCRIPTION
The purpose of this PR is to remove Cagette due to the deletion of the GitHub User and Repository.
Although I searched for a new repository link on [their Website](https://cagette.net/), I was unable to find one. This issue may be due to a misunderstanding caused by Google Translator, as the website is not available in English, and the same seems true for [their wiki](https://wiki.cagette.net/). 
So feel free to double-check here.

ref: #3558 
`https://github.com/CagetteNet/cagette : 404 {"message": "Not Found", "documentation_url": "https://docs.github.com/rest"}`