### PR TITLE
Remove Tasks from Task Management & To-do Lists

### DIFF
--- a/README.md
+++ b/README.md
@@ -1983,7 +1983,6 @@ _Related: [Software Development - Project Management](#software-development---pr
 - [Planka](https://planka.app/) - Open source Trello alternative. ([Demo](https://plankanban.github.io/planka/#/), [Source Code](https://github.com/plankanban/planka)) `AGPL-3.0` `Nodejs`
 - [Restyaboard](https://github.com/RestyaPlatform/board/) - Open source Trello-like kanban board. `OSL-3.0` `PHP`
 - [Task Keeper](https://github.com/nymanjens/piga) - List editor for power users, backed by a self-hosted server. `Apache-2.0` `Scala`
-- [Tasks](https://github.com/m1guelpf/tasks) - Simple tasks and notes manager written in PHP, jQuery and Bootstrap using a custom flat file database. `MPL-2.0` `PHP`
 - [Tasks.md](https://github.com/BaldissaraMatheus/Tasks.md) - A self-hosted, file based task management board that supports Markdown syntax. `MIT` `Docker`
 - [Taskwarrior](https://taskwarrior.org/) - Taskwarrior is Free and Open Source Software that manages your TODO list from your command line. It is flexible, fast, efficient, and unobtrusive. It does its job then gets out of your way. ([Source Code](https://taskwarrior.org/download/#git)) `MIT` `C++`
 - [todo](https://git.mills.io/prologic/todo) - Simple todo list manager. ([Demo](https://todo.mills.io)) `MIT` `Go`


### PR DESCRIPTION
The purpose of this PR is to remove Tasks since it appears to be unmaintained. In the Install Instructions, it still states 'PHP 5.5.9 or higher', which is already long EOL. Installation with newer (supported) versions of PHP seems to result in errors (https://github.com/m1guelpf/Tasks/issues/7).

ref: #3558 
`WARNING:awesome_lint.py: Tasks: last updated -1478 days, 23:22:41.638636 ago, older than 365 days`