### PR TITLE
Remove Bonobo Git Server from Software Development - Project Management

### DIFF
--- a/README.md
+++ b/README.md
@@ -1889,7 +1889,6 @@ Tools and software for [software project management](https://en.wikipedia.org/wi
 
 _Related: [Ticketing](#ticketing), [Task Management & To-do Lists](#task-management--to-do-lists)_
 
-- [Bonobo Git Server](https://bonobogitserver.com/) - Set up your own self hosted git server on IIS for Windows. Manage users and have full control over your repositories with a nice user friendly graphical interface. ([Source Code](https://github.com/jakubgarfield/Bonobo-Git-Server)) `MIT` `C#`
 - [Cgit](https://git.zx2c4.com/cgit/about/) - A fast lightweight web interface for git repositories. ([Source Code](https://git.zx2c4.com/cgit/tree/)) `GPL-2.0` `C`
 - [Fossil](https://www.fossil-scm.org/index.html/doc/trunk/www/index.wiki) - Distributed version control system featuring wiki and bug tracker. `BSD-2-Clause-FreeBSD` `C`
 - [Gerrit](https://www.gerritcodereview.com/) - A code review and project management tool for Git based projects. ([Source Code](https://github.com/GerritCodeReview/gerrit)) `Apache-2.0` `Java/Docker`


### PR DESCRIPTION
The purpose of this PR is to remove Bonobo Git Server from the List due to its lack of maintenance. The project currently has over 160 open issues, with no labelling of issues since August 2017. Additionally, there are 22 open PRs.

ref: #3558 
`WARNING:awesome_lint.py: Bonobo Git Server: last updated -831 days, 23:22:41.654520 ago, older than 365 days`