### PR TITLE
Remove twister (unmaintained since 2022)

### DIFF
--- a/README.md
+++ b/README.md
@@ -583,7 +583,6 @@ Simple deployment of [E-mail](https://en.wikipedia.org/wiki/Email) servers, e.g.
 - [Teddit](https://teddit.net) `⚠` - Alternative Reddit front-end focused on privacy. ([Source Code](https://codeberg.org/teddit/teddit)) `AGPL-3.0` `Nodejs`
 - [Thredded](https://github.com/thredded/thredded) - Forums, feature-rich and simple. `MIT` `Ruby`
 - [Tokumei](https://tokumei.co/) - Anonymous microblogging platform. ([Source Code](https://gitlab.com/tokumei/tokumei)) `ISC` `rc`
-- [twister](http://twister.net.co/) - Fully decentralized P2P microblogging platform leveraging the free software implementations of Bitcoin and BitTorrent protocols. ([Source Code](https://github.com/miguelfreitas/twister-core)) `MIT` `C++`
 - [Vanilla Forums](https://vanillaforums.org/) - Simple and flexible forum software. ([Source Code](https://github.com/vanilla/vanilla)) `GPL-2.0` `PHP`
 - [yarn.social](https://yarn.social) - Self-Hosted, Twitter™-like Decentralised micro-logging platform. No ads, no tracking, your content, your data. ([Source Code](https://git.mills.io/yarnsocial/yarn)) `MIT` `Go`
 - [Zusam](https://github.com/zusam/zusam) - Free and open-source way to self-host private forums for groups of friends or family. ([Demo](https://demo.zusam.org)) `AGPL-3.0` `PHP`


### PR DESCRIPTION
It looks like Twister has been abandoned / unmaintained since 2022. 

Quote from http://twister.net.co/news/:
> Hi!
> 
> It’s a long time since I don’t post, which is a consequence of changing interests and priorities in life over these years. I believe it is > time to admit I won’t be able to keep leading the twister development for the foreseeable future.
> 
> Forking the project is always an option if anyone wants to take over since the code is fully open source. So this announcement only means I’m personally leaving the development not pulling the plug (the twister network is still running).


ref: #3558 
`WARNING:awesome_lint.py: twister: last updated -380 days, 23:18:32.060741 ago, older than 365 days`