### PR TITLE
Remove StockazNG (dead link)

### DIFF
--- a/README.md
+++ b/README.md
@@ -1419,7 +1419,6 @@ _Related: [Inventory Management](#inventory-management), [Resource Planning - En
 - [REI3](https://rei3.de/home_en/) - Open source, expandable Business Management Software. Manage tasks, time, assets and much more. ([Demo](https://rei3.de/demo_en/), [Source Code](https://github.com/r3-team/r3)) `MIT` `Go`
 - [SilverStrike](https://silverstrike.org/) - Personal finance management made easy. ([Demo](https://demo.silverstrike.org/), [Source Code](https://github.com/agstrike/silverstrike)) `MIT` `Python/Django`
 - [SolidInvoice](https://solidinvoice.co) - Open source invoicing and quote application. ([Source Code](https://github.com/SolidInvoice/SolidInvoice)) `MIT` `PHP`
-- [StockazNG](https://dev.sigpipe.me/dashie/StockazNG) - Asset Management System. `MIT` `Python`
 
 
 ### Monitoring


### PR DESCRIPTION
- This link now redirects to https://dev.otter.sh/explore and there is no trace of a project called StockazNG there
- https://github.com/awesome-selfhosted/awesome-selfhosted/issues/3558
