### PR TITLE
Remove xBrowserSync (unmaintained since 2021/2022)

### DIFF
--- a/README.md
+++ b/README.md
@@ -293,7 +293,6 @@ Software which allows users to add, annotate, edit, and share [bookmarks](https:
 - [Shaarli](https://github.com/shaarli/Shaarli) - Personal, minimalist, super-fast, no-database bookmarking and link sharing platform. ([Demo](https://demo.shaarli.org)) `Zlib` `PHP`
 - [Shiori](https://github.com/go-shiori/shiori) - Simple bookmark manager built with Go. `MIT` `Go/Docker`
 - [SyncMarks](https://codeberg.org/Offerel/SyncMarks-Webapp) - Sync and manage your browser bookmarks from Edge, Firefox and Chromium. ([Clients](https://codeberg.org/Offerel/SyncMarks-Extension)) `AGPL-3.0` `PHP`
-- [xBrowserSync](https://www.xbrowsersync.org) - Open source tool for syncing browser data between browsers and devices. ([Source Code](https://github.com/xBrowserSync)) `MIT` `Nodejs`
 
 
 ### Calendar & Contacts - CalDAV or CardDAV Servers


### PR DESCRIPTION
- https://github.com/xbrowsersync/api has no commits since 2021
- https://github.com/xbrowsersync/app has no commits since march 2022
- many untriaged issues, with reports that the software is not working anymore
- alternatives exist
- ref. https://github.com/awesome-selfhosted/awesome-selfhosted/issues/3558
