### PR TITLE
Remove Actionsflow (unmaintained since July 2022)

### DIFF
--- a/README.md
+++ b/README.md
@@ -179,7 +179,6 @@ _Related: [Content Management Systems (CMS)](#content-management-systems-cms)_
 _Related: [Internet of Things (IoT)](#internet-of-things-iot), [Software Development - Continuous Integration & Deployment](#software-development---continuous-integration--deployment)_
 
 - [Accelerated Text](https://github.com/accelerated-text/accelerated-text) - Automatically generate multiple natural language descriptions of your data varying in wording and structure. `Apache-2.0` `Java`
-- [Actionsflow](https://actionsflow.github.io/docs/) `⚠` - The free Zapier/IFTTT alternative for developers to automate your workflows based on Github actions. ([Source Code](https://github.com/actionsflow/actionsflow)) `MIT` `Docker/Nodejs`
 - [Activepieces](https://www.activepieces.com) - No-code business automation tool like Zapier or Tray. For example, you can send a Slack notification for each new Trello card. ([Source Code](https://github.com/activepieces/activepieces)) `MIT` `Typescript`
 - [ActiveWorkflow](https://github.com/automaticmode/active_workflow) - An intelligent process and workflow automation platform based on software agents. `MIT` `Ruby`
 - [AmIUnique](https://amiunique.org/) - Learn how identifiable you are on the Internet (browser fingerprinting tool). ([Source Code](https://github.com/DIVERSIFY-project/amiunique)) `MIT` `Java`


### PR DESCRIPTION
- The most recent commit occurred [more than a year ago](https://github.com/actionsflow/actionsflow/commit/06edc408e8c2d1b0f8de296c2fda759b7027c4e3).
- The main maintainer has mentioned in a [comment](https://github.com/actionsflow/actionsflow/issues/41#issuecomment-1223296681) that they no longer utilize the software.
- The software has dependencies that are now outdated.

ref: #3558
```
ERROR:awesome_lint.py: Actionsflow: last updated -403 days, 1:33:27.079919 ago, older than 365 days
WARNING:awesome_lint.py: Actionsflow: last updated -403 days, 1:33:27.079919 ago, older than 186 days
```