### PR TITLE
Remove budgetzero (unmaintained since Aug 2022)

### DIFF
--- a/README.md
+++ b/README.md
@@ -1402,7 +1402,6 @@ _Related: [Inventory Management](#inventory-management), [Resource Planning - En
 - [Bitcart](https://bitcart.ai) - A self-hosted cryptocurrencies payment processor and development platform. ([Demo](https://admin.bitcart.ai), [Source Code](https://github.com/bitcart)) `MIT` `Docker/Python/Nodejs`
 - [BTCPay Server](https://btcpayserver.org/) - A self-hosted Bitcoin and other cryptocurrencies payment processor. ([Demo](https://mainnet.demo.btcpayserver.org/), [Source Code](https://github.com/btcpayserver/)) `MIT` `C#`
 - [Budget Zen](https://budgetzen.net) - End-to-end encrypted and simple expense manager. ([Demo](https://app.budgetzen.net), [Source Code](https://github.com/BrunoBernardino/budgetzen-web)) `AGPL-3.0` `Deno`
-- [budgetzero](https://github.com/budgetzero/budgetzero) - Free, self-hosted, open-source, envelope-budgeting web and desktop app. ([Demo](https://app.budgetzero.io/budget)) `AGPL-3.0` `Nodejs`
 - [Crater](https://github.com/crater-invoice/crater) - Free & Open Source Invoice App for Freelancers & Small Businesses. ([Demo](https://demo.craterapp.com/)) `AAL` `PHP`
 - [DePay](https://depay.com) - Accept Web3 Payments directly into your wallet. Peer-to-peer, free, self-hosted & open-source. ([Demo](https://depay.com/products/payments), [Source Code](https://github.com/depayfi/widgets)) `MIT` `Nodejs`
 - [Family Accounting Tool](https://github.com/nymanjens/facto) - Web-based finance management tool for partners with partially shared expenses. `Apache-2.0` `Scala`


### PR DESCRIPTION
- The most recent commit occurred [one year ago](https://github.com/budgetzero/budgetzero/commit/3b901f4c2771c96dccbdfca8661d3360ba93a161). However, the official Docker image has not been updated for [two years](https://hub.docker.com/r/budgetzero/budgetzero).
- There are currently [open pull requests](https://github.com/budgetzero/budgetzero/pulls?q=is%3Apr+is%3Aopen+label%3Adependencies) addressing outdated dependencies.

ref: #3558 
```
ERROR:awesome_lint.py: budgetzero: last updated -373 days, 1:33:27.071703 ago, older than 365 days
WARNING:awesome_lint.py: budgetzero: last updated -373 days, 1:33:27.071703 ago, older than 186 days
```