### PR TITLE
Remove adminer (unmaintained since May 2021)

### DIFF
--- a/README.md
+++ b/README.md
@@ -727,7 +727,6 @@ _Related: [Analytics](#analytics), [Automation](#automation)_
 
 _See also: [dbdb.io - Database of Databases](https://dbdb.io/)_
 
-- [Adminer](https://www.adminer.org/) - Database management in a single PHP file. Available for MySQL, MariaDB, PostgreSQL, SQLite, MS SQL, Oracle, Elasticsearch, MongoDB and others. ([Source Code](https://github.com/vrana/adminer/)) `Apache-2.0/GPL-2.0` `PHP`
 - [Baserow](https://baserow.io/) - Open source online database tool and Airtable alternative. Create your own database without technical experience. ([Source Code](https://gitlab.com/bramw/baserow)) `MIT` `Docker`
 - [Bytebase](https://www.bytebase.com/) - Safe database schema change and version control for DevOps teams, supports MySQL, PostgreSQL, TiDB, ClickHouse, and Snowflake. ([Demo](https://demo.bytebase.com), [Source Code](https://github.com/bytebase/bytebase)) `MIT` `Docker/K8S/Go`
 - [Chartbrew](https://chartbrew.com) - Web application that can connect directly to databases and APIs and use the data to create beautiful charts. ([Demo](https://app.chartbrew.com/live-demo), [Source Code](https://github.com/chartbrew/chartbrew)) `MIT` `Nodejs/Docker`


### PR DESCRIPTION
- The most recent commit took place [2 years ago](https://github.com/vrana/adminer/commit/88647b93e467210f270340e758af6771e2c5638a).
- There is no active review or response to [pull requests](https://github.com/vrana/adminer/pulls) or [issues](https://sourceforge.net/p/adminer/discussion/960418/).
- Following this [issue](https://sourceforge.net/p/adminer/bugs-and-features/853/), the current version of Adminer appears to be incompatible with PHP 8.2.

As far as I have seen, there is a [new fork](https://github.com/adminerevo/adminerevo) of adminer which wants to continue painting the software. However, since the fork is relatively new, I didn't want to add it yet.

ref: #3558
```
ERROR:awesome_lint.py: Adminer: last updated -843 days, 1:33:27.079097 ago, older than 365 days
WARNING:awesome_lint.py: Adminer: last updated -843 days, 1:33:27.079097 ago, older than 186 days
```