### PR TITLE
Remove EdPaste (unmaintained since Jan 2019)

### DIFF
--- a/README.md
+++ b/README.md
@@ -1520,7 +1520,6 @@ A [pastebin](https://en.wikipedia.org/wiki/Pastebin) is a type of online content
 - [bin](https://github.com/w4/bin) - A paste bin that's actually minimalist. `WTFPL/0BSD` `Rust`
 - [dpaste](https://dpaste.org/) - Simple pastebin with multiple text and code option, with short url result easy to remember. ([Source Code](https://github.com/DarrenOfficial/dpaste)) `MIT` `Docker`
 - [Drift](https://github.com/MaxLeiter/drift) - Self-hosted Github Gist clone. ([Demo](https://drift.maxleiter.com/)) `MIT` `Nodejs`
-- [EdPaste](https://github.com/ptnr/EdPaste) - Self-hosted pastebin written in Laravel (PHP Framework). `MIT` `PHP`
 - [ExBin](https://github.com/m1dnight/exbin) - A pastebin with public/private snippets and netcat server. `MIT` `Elixir`
 - [fiche](https://github.com/solusipse/fiche) - Command line pastebin, all you need is netcat. ([Demo](https://termbin.com/)) `MIT` `C`
 - [filite](https://github.com/raftario/filite) - A simple, light and standalone pastebin, URL shortener and file-sharing service. `MIT` `Rust`


### PR DESCRIPTION
- Although the most recent commit occurred just [one year ago](https://github.com/ptnr/EdPaste/commit/b50c25e92f07dd0b5a671b32b7b8c05ecfc28cc4), the last code modification took place [3 years ago](https://github.com/ptnr/EdPaste/commit/47e61bc885de2eca4725cdba562d29378378ecb1).
- Numerous other actively maintained PHP Pastebins are present on this list.

ref: #3558
```
ERROR:awesome_lint.py: EdPaste: last updated -502 days, 1:33:27.061195 ago, older than 365 days
WARNING:awesome_lint.py: EdPaste: last updated -502 days, 1:33:27.061195 ago, older than 186 days
```