### PR TITLE
fix: issue template to new github format

### DIFF
--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,5 @@
+blank_issues_enabled: false
+contact_links:
+  - name: "Awesome Selfhosted Data"
+    url: "https://github.com/awesome-selfhosted/awesome-selfhosted-data/issues"
+    about: "Please submit your issues or suggestions to the awesome-selfhosted-data repository instead."

--- a/.github/issue_template.md
+++ b/.github/issue_template.md
@@ -1,1 +1,0 @@
-Please do not open issues in this repository. Use https://github.com/awesome-selfhosted/awesome-selfhosted-data instead.


### PR DESCRIPTION
Lately, we've started receiving issues again in the old repository. To prevent this, we should fix the currently broken issue template by adding an automatic redirect to the new repository. This way, issues can no longer be opened in the current repo.

Preview of the change:
![2025-03-31-14-48_766](https://github.com/user-attachments/assets/50f64d8b-400c-48db-afed-3b4e2e37fb4d)
